### PR TITLE
Feature/EnemyEdgeDetection

### DIFF
--- a/Assets/Resources/Prefabs/MeleeEnemy1_2.prefab
+++ b/Assets/Resources/Prefabs/MeleeEnemy1_2.prefab
@@ -1,0 +1,524 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2165544603971447547
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1477630465055884991}
+  - component: {fileID: 2449468010808055053}
+  - component: {fileID: 4992420694920009114}
+  m_Layer: 0
+  m_Name: Renderer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1477630465055884991
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2165544603971447547}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.22, z: 0}
+  m_LocalScale: {x: 0.33340102, y: 0.33333334, z: 0.9993912}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3260529182925472828}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2449468010808055053
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2165544603971447547}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 1
+  m_Sprite: {fileID: 21300000, guid: d102cada2fff5464e85b553ea15b4387, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.65, y: 1.65}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!95 &4992420694920009114
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2165544603971447547}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 96b5e3d621ce45f47908738a3537e956, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+--- !u!1 &3643720543023382595
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5722364345517668555}
+  - component: {fileID: 3969943416859128171}
+  - component: {fileID: 1709160410}
+  m_Layer: 0
+  m_Name: AttackRange
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5722364345517668555
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3643720543023382595}
+  m_LocalRotation: {x: -0, y: -1, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.33333334, y: 0.33333334, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3260529182925472828}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &3969943416859128171
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3643720543023382595}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 1.5}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 3.5, y: 3}
+  m_EdgeRadius: 0
+--- !u!114 &1709160410
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3643720543023382595}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1f5a0f8c7c216b548a38e0baf2486fb8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &5456784485947500350
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6222344025103955859}
+  - component: {fileID: 2874281276949492762}
+  - component: {fileID: 92584292}
+  m_Layer: 0
+  m_Name: ChaseRange
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6222344025103955859
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5456784485947500350}
+  m_LocalRotation: {x: -0, y: -1, z: -0, w: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.33333334, y: 0.33333334, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3260529182925472828}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &2874281276949492762
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5456784485947500350}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 3.5}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 20, y: 7}
+  m_EdgeRadius: 0
+--- !u!114 &92584292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5456784485947500350}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 44f551130f1b3ed4eb1a7f86f51eb180, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7154700476304014582
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3260529182925472828}
+  - component: {fileID: 2854206439868323322}
+  - component: {fileID: 9036694678958889534}
+  - component: {fileID: 3876051710393344225}
+  - component: {fileID: 3842903198805543405}
+  - component: {fileID: 1576205176}
+  - component: {fileID: 1918481558}
+  - component: {fileID: 5349268765530089570}
+  m_Layer: 5
+  m_Name: MeleeEnemy1_2
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3260529182925472828
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7154700476304014582}
+  m_LocalRotation: {x: 0, y: 0.008726558, z: 0, w: 0.999962}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5722364345517668555}
+  - {fileID: 6222344025103955859}
+  - {fileID: 5760656626525738439}
+  - {fileID: 1477630465055884991}
+  - {fileID: 6940682047945243524}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 1, z: 0}
+--- !u!50 &2854206439868323322
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7154700476304014582}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 50
+  m_LinearDrag: 1
+  m_AngularDrag: 0.05
+  m_GravityScale: 1
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4
+--- !u!70 &9036694678958889534
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7154700476304014582}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0.3}
+  m_Size: {x: 0.5, y: 0.7}
+  m_Direction: 0
+--- !u!114 &3876051710393344225
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7154700476304014582}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 80d00db5dfe13d84da7af081cdade890, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyStatus: {fileID: 3842903198805543405}
+  enemyAnimator: {fileID: 4992420694920009114}
+  attackRangeCol: {fileID: 1576205176}
+  chaseRangeCol: {fileID: 2874281276949492762}
+  enemyController: {fileID: 1918481558}
+  playerTransform: {fileID: 0}
+  enemyRigidbody: {fileID: 2854206439868323322}
+  speed: 5
+  groundCheckPoint: {fileID: 6940682047945243524}
+  groundCheckDistance: 2
+  groundLayer:
+    serializedVersion: 2
+    m_Bits: 4096
+  hitBoxObj: {fileID: 8901037968461984229}
+--- !u!114 &3842903198805543405
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7154700476304014582}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 911c3f35092100a478218d2cbcaba56a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  enemyData: {fileID: 11400000, guid: 40843861306502d48ae24fd524055e43, type: 2}
+--- !u!61 &1576205176
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7154700476304014582}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0.4}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1.2}
+  m_EdgeRadius: 0
+--- !u!114 &1918481558
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7154700476304014582}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9f898987560aeb14c8dfe73cde4109db, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isChasing: 0
+  isDead: 0
+--- !u!114 &5349268765530089570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7154700476304014582}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: beb850f9f87cb7e4ea782edefb8e8963, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7413816408706172057
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6940682047945243524}
+  m_Layer: 0
+  m_Name: GroundCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6940682047945243524
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7413816408706172057}
+  m_LocalRotation: {x: -0, y: -0.008726558, z: -0, w: 0.999962}
+  m_LocalPosition: {x: -0.3, y: 0, z: 0}
+  m_LocalScale: {x: 0.33340102, y: 0.33333334, z: 0.9993912}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3260529182925472828}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8901037968461984229
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5760656626525738439}
+  - component: {fileID: 488687963708116845}
+  - component: {fileID: 593694728}
+  m_Layer: 5
+  m_Name: HitBox
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &5760656626525738439
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8901037968461984229}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3260529182925472828}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &488687963708116845
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8901037968461984229}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &593694728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8901037968461984229}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aecd4811cde0351409ae495a761d868c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hitBoxCol: {fileID: 488687963708116845}
+  damage: 0

--- a/Assets/Resources/Prefabs/MeleeEnemy1_2.prefab.meta
+++ b/Assets/Resources/Prefabs/MeleeEnemy1_2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ccf36d70f958cf1409487598c05b9da5
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/PlayerRefactoringTestScene.unity
+++ b/Assets/Scenes/PlayerRefactoringTestScene.unity
@@ -515,7 +515,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 208179301}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: Right
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -777,7 +777,7 @@ GameObject:
   - component: {fileID: 276597755}
   - component: {fileID: 276597754}
   - component: {fileID: 276597753}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: Floor
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -1603,7 +1603,9 @@ MonoBehaviour:
   characterName: {fileID: 1194345129}
   statusTextPref: {fileID: 5530336742706271555, guid: 2aebc3a8aee99684ca85ccd00032d1c5, type: 3}
   statusParentObj: {fileID: 1429028546}
+  characterInfo: {fileID: 0}
   playerStatus: {fileID: 0}
+  closeButton: {fileID: 0}
 --- !u!1 &492220239
 GameObject:
   m_ObjectHideFlags: 0
@@ -4668,7 +4670,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1166246389}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: Left
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -6349,6 +6351,63 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1507765981}
   m_CullTransparentMesh: 1
+--- !u!1001 &1520248992
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -15.44
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.96
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.999962
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.008726558
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7154700476304014582, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
+      propertyPath: m_Name
+      value: MeleeEnemy1_2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
 --- !u!1 &1557490274
 GameObject:
   m_ObjectHideFlags: 0
@@ -6544,6 +6603,10 @@ PrefabInstance:
     - target: {fileID: 7154700476304014582, guid: 9613631fc802fb741a93551540bf00d4, type: 3}
       propertyPath: m_Name
       value: MeleeEnemy1_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7154700476304014582, guid: 9613631fc802fb741a93551540bf00d4, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9613631fc802fb741a93551540bf00d4, type: 3}
@@ -6810,7 +6873,7 @@ GameObject:
   - component: {fileID: 1674221320}
   - component: {fileID: 1674221319}
   - component: {fileID: 1674221318}
-  m_Layer: 0
+  m_Layer: 12
   m_Name: Floor (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/Enemy/ChaseState.cs
+++ b/Assets/Scripts/Enemy/ChaseState.cs
@@ -13,6 +13,7 @@ public class ChaseState : IState
 
     public void Enter()
     {
+        enemy.OnEdgeDetected += StopAtEdge;
         enemy.StateMachine.isChasing = true;
     }
 
@@ -25,13 +26,20 @@ public class ChaseState : IState
     {
         if (enemy.PlayerTransform != null)
         {
-            enemy.Rigidbody.velocity = (enemy.PlayerTransform.position.x > enemy.transform.position.x) ? Vector2.right : Vector2.left;
-            enemy.Rigidbody.velocity *= enemy.EnemyStatus.TotalMoveSpeed;
+            Vector2 chaseDirection = (enemy.PlayerTransform.position.x > enemy.transform.position.x) ? Vector2.right : Vector2.left;
+            enemy.Rigidbody.velocity = new Vector2(chaseDirection.x * enemy.Speed, enemy.Rigidbody.velocity.y);
         }
     }
 
     public void Exit()
     {
+        enemy.OnEdgeDetected -= StopAtEdge;
+        enemy.Rigidbody.velocity = Vector2.zero;
+    }
+
+    private void StopAtEdge()
+    {
+        // 플랫폼 끝에 도달했을 때 정지
         enemy.Rigidbody.velocity = Vector2.zero;
     }
 }

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -24,23 +24,26 @@ public class Enemy : MonoBehaviour
     protected Transform playerTransform;
 
     [SerializeField]
-    protected Transform leftEdge;
-
-    [SerializeField]
-    protected Transform rightEdge;
-
-    [SerializeField]
     protected Rigidbody2D enemyRigidbody;
 
     [SerializeField]
     protected float speed = 3f;
 
+    [SerializeField]
+    private Transform groundCheckPoint;
+
+    [SerializeField]
+    private float groundCheckDistance = 1f;
+
+    [SerializeField]
+    private LayerMask groundLayer;
+
+    public event Action OnEdgeDetected;
+
     public EnemyStatus EnemyStatus { get { return enemyStatus; } }
     public EnemyAIController StateMachine { get { return enemyController; } }
     public BoxCollider2D AttackRangeCol { get { return attackRangeCol; } }
     public BoxCollider2D ChaseRangeCol { get { return chaseRangeCol; } }
-    public Transform LeftEdge { get { return leftEdge; } }
-    public Transform RightEdge { get { return rightEdge; } }
     public Transform PlayerTransform { get { return playerTransform; } }
     public float Speed { get { return speed; } }
     public Rigidbody2D Rigidbody { get { return enemyRigidbody; } }
@@ -66,7 +69,7 @@ public class Enemy : MonoBehaviour
     protected virtual void FixedUpdate()
     {
         FlipX();
-        CheckEdge();
+        CheckPlatformEdge();
     }
 
     protected void FlipX()
@@ -102,15 +105,15 @@ public class Enemy : MonoBehaviour
 
     }
 
-    protected void CheckEdge()
+    protected void CheckPlatformEdge()
     {
-        if (transform.position.x >= RightEdge.transform.position.x)
+        bool isGroundAhead = Physics2D.Raycast(groundCheckPoint.position, Vector2.down, groundCheckDistance, groundLayer);
+
+        Debug.DrawRay(groundCheckPoint.position, Vector2.down * groundCheckDistance, isGroundAhead ? Color.green : Color.red);
+
+        if (!isGroundAhead)
         {
-            transform.position = new Vector3(RightEdge.transform.position.x, transform.position.y, transform.position.z);
-        }
-        else if(transform.position.x <= LeftEdge.transform.position.x)
-        {
-            transform.position = new Vector3(LeftEdge.transform.position.x, transform.position.y, transform.position.z);
+            OnEdgeDetected.Invoke();
         }
     }
 

--- a/Assets/Scripts/Enemy/WanderState.cs
+++ b/Assets/Scripts/Enemy/WanderState.cs
@@ -5,9 +5,11 @@ using UnityEngine;
 public class WanderState : IState
 {
     private Enemy enemy;
-    private float movePos;
     private Vector2 direction;
-    private float value;
+
+    private float wanderTime = 1f; // 한 방향으로 이동하는 시간
+    private float currentTime = 0f;
+
 
     public WanderState(Enemy enemy)
     {
@@ -16,14 +18,27 @@ public class WanderState : IState
 
     public void Enter()
     {
+        enemy.OnEdgeDetected += ChangeDirection;
+
         enemy.EnemyAnimator.SetBool("isMove", true);
-        movePos = Random.Range(enemy.LeftEdge.position.x, enemy.RightEdge.position.x);
-        direction = (movePos > enemy.transform.position.x) ? Vector2.right : Vector2.left;
+
+        // 좌우 랜덤 방향 설정
+        float randomValue = Random.value;
+        direction = (randomValue > 0.5f) ? Vector2.right : Vector2.left;
+
+        // 이동 시간 초기화
+        currentTime = 0f;
     }
 
     public void Update(float delta)
     {
-        
+        currentTime += delta;
+
+        // 일정 시간 후 Idle 상태 전환
+        if (currentTime >= wanderTime && enemy.StateMachine.isChasing == false)
+        {
+            enemy.StateMachine.TransitionTo(enemy.StateMachine.idleState);
+        }
     }
 
     public void FixedUpdate()
@@ -33,6 +48,8 @@ public class WanderState : IState
 
     public void Exit()
     {
+        enemy.OnEdgeDetected -= ChangeDirection;
+
         enemy.EnemyAnimator.SetBool("isMove", false);
         enemy.Rigidbody.velocity = Vector2.zero;
         direction = Vector2.zero;
@@ -40,31 +57,11 @@ public class WanderState : IState
 
     void SetVelocity()
     {
-        if (direction.x >= 1f)
-        {
-            if (enemy.Rigidbody.position.x >= movePos)
-            {
-                enemy.Rigidbody.velocity = Vector2.zero;
-                if (enemy.StateMachine.isChasing == false)
-                    enemy.StateMachine.TransitionTo(enemy.StateMachine.idleState);
-            }
-            else
-            {
-                enemy.Rigidbody.velocity = direction * enemy.Speed;
-            }
-        }
-        else if (direction.x <= -1f)
-        {
-            if (enemy.Rigidbody.position.x <= movePos)
-            {
-                enemy.Rigidbody.velocity = Vector2.zero;
-                if(enemy.StateMachine.isChasing == false)
-                    enemy.StateMachine.TransitionTo(enemy.StateMachine.idleState);
-            }
-            else
-            {
-                enemy.Rigidbody.velocity = direction * enemy.Speed;
-            }
-        }
+        enemy.Rigidbody.velocity = new Vector2(direction.x * enemy.Speed, enemy.Rigidbody.velocity.y);
+    }
+
+    private void ChangeDirection()
+    {
+        direction = (direction == Vector2.right) ? Vector2.left : Vector2.right;
     }
 }


### PR DESCRIPTION
- 이슈 번호 : #120 
- 구현 사항
  - Enemy.cs에 Raycast를 이용한 발판 끝 감지 로직 추가
  - 해당 로직 반영된 MeleeEnemy1_2 프리팹 생성
  - OnEdgeDetected 이벤트 추가. 발판 끝에서 Invoke.
  - WanderState에서 Edge 감지 이벤트 구독 및 호출 시 방향 전환
  - ChaseState에서 Edge 감지 이벤트 구독 및 호출 시 정지
  - 상태 전환 시 이벤트 구독/해제
  - 기존 LeftEdge, RightEdge 의존 로직 제거
  - Debug.DrawRay 추가로 Scene 내 Raycast 시각화