### PR TITLE
Feature/EnemyEdgeDetection2

### DIFF
--- a/Assets/Resources/Prefabs/MeleeEnemy1_2.prefab
+++ b/Assets/Resources/Prefabs/MeleeEnemy1_2.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 1477630465055884991}
   - component: {fileID: 2449468010808055053}
   - component: {fileID: 4992420694920009114}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Renderer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -116,7 +116,7 @@ GameObject:
   - component: {fileID: 5722364345517668555}
   - component: {fileID: 3969943416859128171}
   - component: {fileID: 1709160410}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: AttackRange
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -187,7 +187,7 @@ GameObject:
   - component: {fileID: 6222344025103955859}
   - component: {fileID: 2874281276949492762}
   - component: {fileID: 92584292}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: ChaseRange
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -222,7 +222,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 3.5}
+  m_Offset: {x: 0, y: 1.7}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -233,7 +233,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 20, y: 7}
+  m_Size: {x: 10, y: 3}
   m_EdgeRadius: 0
 --- !u!114 &92584292
 MonoBehaviour:
@@ -263,7 +263,7 @@ GameObject:
   - component: {fileID: 1576205176}
   - component: {fileID: 1918481558}
   - component: {fileID: 5349268765530089570}
-  m_Layer: 5
+  m_Layer: 9
   m_Name: MeleeEnemy1_2
   m_TagString: Enemy
   m_Icon: {fileID: 0}
@@ -427,7 +427,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6940682047945243524}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: GroundCheck
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -441,14 +441,14 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7413816408706172057}
-  m_LocalRotation: {x: -0, y: -0.008726558, z: -0, w: 0.999962}
+  m_LocalRotation: {x: 0, y: -0.008726465, z: 0, w: 0.999962}
   m_LocalPosition: {x: -0.3, y: 0, z: 0}
   m_LocalScale: {x: 0.33340102, y: 0.33333334, z: 0.9993912}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3260529182925472828}
   m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: -1, z: 0}
 --- !u!1 &8901037968461984229
 GameObject:
   m_ObjectHideFlags: 0
@@ -460,7 +460,7 @@ GameObject:
   - component: {fileID: 5760656626525738439}
   - component: {fileID: 488687963708116845}
   - component: {fileID: 593694728}
-  m_Layer: 5
+  m_Layer: 9
   m_Name: HitBox
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/Enemy/ChaseState.cs
+++ b/Assets/Scripts/Enemy/ChaseState.cs
@@ -24,10 +24,14 @@ public class ChaseState : IState
 
     public void FixedUpdate()
     {
-        if (enemy.PlayerTransform != null)
+        if (enemy.PlayerTransform != null && !enemy.IsEdgeDetected)
         {
             Vector2 chaseDirection = (enemy.PlayerTransform.position.x > enemy.transform.position.x) ? Vector2.right : Vector2.left;
             enemy.Rigidbody.velocity = new Vector2(chaseDirection.x * enemy.Speed, enemy.Rigidbody.velocity.y);
+        }
+        else
+        {
+            enemy.Rigidbody.velocity = Vector2.zero;
         }
     }
 

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -51,6 +51,8 @@ public class Enemy : MonoBehaviour
 
     public event Action<Enemy> onDeath;
 
+    public bool IsEdgeDetected { get; private set; }
+
     protected virtual void Awake()
     {
         enemyRigidbody = GetComponent<Rigidbody2D>();
@@ -113,7 +115,12 @@ public class Enemy : MonoBehaviour
 
         if (!isGroundAhead)
         {
-            OnEdgeDetected.Invoke();
+            IsEdgeDetected = true;
+            OnEdgeDetected?.Invoke();
+        }
+        else
+        {
+            IsEdgeDetected = false;
         }
     }
 

--- a/Assets/Scripts/Enemy/MeleeEnemy.cs
+++ b/Assets/Scripts/Enemy/MeleeEnemy.cs
@@ -11,12 +11,11 @@ public class MeleeEnemy : Enemy
     {
         base.Awake();
         AttackRangeCol.size = new Vector2(enemyStatus.EnemyStatusData.AttackRange, AttackRangeCol.size.y);
-        StateMachine.Initialize(this);
     }
 
     void Start()
     {
-
+        StateMachine.Initialize(this);
     }
 
     void Update()

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffff7fffffff3fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffff7fffffff3ffffffffffffffffffdffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -774,7 +774,7 @@ PlayerSettings:
   allowUnsafeCode: 0
   useDeterministicCompilation: 1
   enableRoslynAnalyzers: 1
-  selectedPlatform: 0
+  selectedPlatform: 1
   additionalIl2CppArgs: 
   scriptingRuntimeVersion: 1
   gcIncremental: 1

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -17,7 +17,7 @@ TagManager:
   - Player
   - Projectile
   - FloatingTile
-  - 
+  - Enemy
   - 
   - 
   - GroundTile


### PR DESCRIPTION
- 이슈 번호 : #125 
- 구현 사항
  - 아래 에러 현상을 해결
    - 적 사망 이후 OnEdgeDetected 이벤트 호출 시 null에러 발생하는 현상
    - 추적 상태에서 플랫폼 끝을 뚫고 이동하는 현상
    - 스폰 초기 상태 머신 초기화가 이루어지지 않는 현상
    - 동일 플랫폼 위 적들이 이동 간 충돌하여 플랫폼 밖으로 밀려나는 현상
  - 세부 내역은 이슈 참고