### PR TITLE
Feature/MeleeDebuffEnemy

### DIFF
--- a/Assets/MeleeDebuffEnemyData.asset
+++ b/Assets/MeleeDebuffEnemyData.asset
@@ -1,0 +1,23 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3aa113f20b493274ebfc1d5dfe868b28, type: 3}
+  m_Name: MeleeDebuffEnemyData
+  m_EditorClassIdentifier: 
+  enemyName: Melee
+  hp: 1
+  damage: 1
+  damageReduction: 0
+  attackSpeed: 1
+  moveSpeed: 2
+  attackRange: 2
+  sightRange: 1
+  expValue: 100

--- a/Assets/MeleeDebuffEnemyData.asset.meta
+++ b/Assets/MeleeDebuffEnemyData.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 12d61e069afe6414eb0e8ae4da6e524b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Blacksmith/Animator/OneHanded_Animator.controller
+++ b/Assets/Resources/Blacksmith/Animator/OneHanded_Animator.controller
@@ -10,7 +10,82 @@ AnimatorState:
   m_Name: Idle
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: -3850412431063680578}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 92034ca7c9f3e1745a6a4b4b2647aee9, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-3850412431063680578
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: Attack
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -3230702950537048640}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.42307693
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &-3411636620267472104
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions: []
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -5811733856794409407}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0.25
+  m_TransitionOffset: 0
+  m_ExitTime: 0.42307693
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-3230702950537048640
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Idle 0
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -3411636620267472104}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -40,25 +115,25 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Die
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isMove
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -84,6 +159,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: -5811733856794409407}
     m_Position: {x: 396.0714, y: 36.19043, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -3230702950537048640}
+    m_Position: {x: 640, y: 20, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions: []
   m_EntryTransitions: []

--- a/Assets/Resources/Prefabs/MeleeDebuffEnemy1_1.prefab
+++ b/Assets/Resources/Prefabs/MeleeDebuffEnemy1_1.prefab
@@ -11,7 +11,7 @@ GameObject:
   - component: {fileID: 1477630465055884991}
   - component: {fileID: 2449468010808055053}
   - component: {fileID: 4992420694920009114}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: Renderer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -116,7 +116,7 @@ GameObject:
   - component: {fileID: 5722364345517668555}
   - component: {fileID: 3969943416859128171}
   - component: {fileID: 1709160410}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: AttackRange
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -187,7 +187,7 @@ GameObject:
   - component: {fileID: 6222344025103955859}
   - component: {fileID: 2874281276949492762}
   - component: {fileID: 92584292}
-  m_Layer: 0
+  m_Layer: 9
   m_Name: ChaseRange
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -222,7 +222,7 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 3.5}
+  m_Offset: {x: 0, y: 1.7}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -233,7 +233,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 20, y: 7}
+  m_Size: {x: 10, y: 3}
   m_EdgeRadius: 0
 --- !u!114 &92584292
 MonoBehaviour:
@@ -258,13 +258,13 @@ GameObject:
   - component: {fileID: 3260529182925472828}
   - component: {fileID: 2854206439868323322}
   - component: {fileID: 9036694678958889534}
-  - component: {fileID: 3876051710393344225}
+  - component: {fileID: 4116802487966569988}
   - component: {fileID: 3842903198805543405}
   - component: {fileID: 1576205176}
   - component: {fileID: 1918481558}
   - component: {fileID: 5349268765530089570}
-  m_Layer: 5
-  m_Name: MeleeEnemy1_1
+  m_Layer: 9
+  m_Name: MeleeDebuffEnemy1_1
   m_TagString: Enemy
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -286,6 +286,7 @@ Transform:
   - {fileID: 6222344025103955859}
   - {fileID: 5760656626525738439}
   - {fileID: 1477630465055884991}
+  - {fileID: 6940682047945243524}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 1, z: 0}
@@ -326,7 +327,7 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0.3}
   m_Size: {x: 0.5, y: 0.7}
   m_Direction: 0
---- !u!114 &3876051710393344225
+--- !u!114 &4116802487966569988
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -335,23 +336,25 @@ MonoBehaviour:
   m_GameObject: {fileID: 7154700476304014582}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 80d00db5dfe13d84da7af081cdade890, type: 3}
+  m_Script: {fileID: 11500000, guid: 2d28eedbf8a2c3e408e4804710d8718c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   enemyStatus: {fileID: 3842903198805543405}
   enemyAnimator: {fileID: 4992420694920009114}
-  attackRangeCol: {fileID: 1576205176}
+  attackRangeCol: {fileID: 3969943416859128171}
   chaseRangeCol: {fileID: 2874281276949492762}
   enemyController: {fileID: 1918481558}
   playerTransform: {fileID: 0}
   enemyRigidbody: {fileID: 2854206439868323322}
-  speed: 5
-  groundCheckPoint: {fileID: 0}
-  groundCheckDistance: 1
+  speed: 3
+  groundCheckPoint: {fileID: 6940682047945243524}
+  groundCheckDistance: 2
   groundLayer:
     serializedVersion: 2
-    m_Bits: 0
+    m_Bits: 4096
   hitBoxObj: {fileID: 8901037968461984229}
+  debuffDuration: 3
+  debuffAmount: 0.5
 --- !u!114 &3842903198805543405
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -417,6 +420,37 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: beb850f9f87cb7e4ea782edefb8e8963, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &7413816408706172057
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6940682047945243524}
+  m_Layer: 9
+  m_Name: GroundCheck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6940682047945243524
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7413816408706172057}
+  m_LocalRotation: {x: 0, y: -0.008726465, z: 0, w: 0.999962}
+  m_LocalPosition: {x: -0.3, y: 0, z: 0}
+  m_LocalScale: {x: 0.33340102, y: 0.33333334, z: 0.9993912}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3260529182925472828}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: -1, z: 0}
 --- !u!1 &8901037968461984229
 GameObject:
   m_ObjectHideFlags: 0
@@ -428,7 +462,7 @@ GameObject:
   - component: {fileID: 5760656626525738439}
   - component: {fileID: 488687963708116845}
   - component: {fileID: 593694728}
-  m_Layer: 5
+  m_Layer: 9
   m_Name: HitBox
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/MeleeDebuffEnemy1_1.prefab.meta
+++ b/Assets/Resources/Prefabs/MeleeDebuffEnemy1_1.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9b556d724c2e0444faccb39789803164
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/PlayerRefactoringTestScene.unity
+++ b/Assets/Scenes/PlayerRefactoringTestScene.unity
@@ -896,7 +896,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &299414341
 GameObject:
@@ -2735,7 +2735,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3260529182925472828, guid: 4aae8608690ec0244a1406536d6d703e, type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 3260529182925472828, guid: 4aae8608690ec0244a1406536d6d703e, type: 3}
       propertyPath: m_LocalPosition.x
@@ -2780,6 +2780,10 @@ PrefabInstance:
     - target: {fileID: 7154700476304014582, guid: 4aae8608690ec0244a1406536d6d703e, type: 3}
       propertyPath: m_Name
       value: RangedEnemy1_1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7154700476304014582, guid: 4aae8608690ec0244a1406536d6d703e, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4aae8608690ec0244a1406536d6d703e, type: 3}
@@ -3946,7 +3950,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1016594462
 GameObject:
@@ -5705,7 +5709,7 @@ RectTransform:
   - {fileID: 475009537}
   - {fileID: 738993314}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -6417,7 +6421,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 3260529182925472828, guid: ccf36d70f958cf1409487598c05b9da5, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6615,7 +6619,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 3260529182925472828, guid: 9613631fc802fb741a93551540bf00d4, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3260529182925472828, guid: 9613631fc802fb741a93551540bf00d4, type: 3}
       propertyPath: m_LocalPosition.x
@@ -6657,6 +6661,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3842903198805543405, guid: 9613631fc802fb741a93551540bf00d4, type: 3}
+      propertyPath: enemyData
+      value: 
+      objectReference: {fileID: 11400000, guid: 40843861306502d48ae24fd524055e43, type: 2}
     - target: {fileID: 3876051710393344225, guid: 9613631fc802fb741a93551540bf00d4, type: 3}
       propertyPath: leftEdge
       value: 
@@ -6879,6 +6887,64 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1627873538}
   m_CullTransparentMesh: 1
+--- !u!1001 &1638661655
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -12.512629
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3.9425325
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.999962
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.008726558
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3260529182925472828, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7154700476304014582, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+      propertyPath: m_Name
+      value: MeleeDebuffEnemy1_1
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 593694728, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 9b556d724c2e0444faccb39789803164, type: 3}
 --- !u!1 &1649030709
 GameObject:
   m_ObjectHideFlags: 0
@@ -6926,6 +6992,32 @@ RectTransform:
   m_AnchoredPosition: {x: 491, y: -350}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1664359002 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8901037968461984229, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+  m_PrefabInstance: {fileID: 1638661655}
+  m_PrefabAsset: {fileID: 0}
+--- !u!61 &1664359004 stripped
+BoxCollider2D:
+  m_CorrespondingSourceObject: {fileID: 488687963708116845, guid: 9b556d724c2e0444faccb39789803164, type: 3}
+  m_PrefabInstance: {fileID: 1638661655}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1664359006
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1664359002}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 022178568cd22c3408834ac9f36b0e52, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hitBoxCol: {fileID: 1664359004}
+  damage: 0
+  slowAmount: 0.3
+  slowDuration: 3
 --- !u!1 &1674221317
 GameObject:
   m_ObjectHideFlags: 0
@@ -7059,7 +7151,7 @@ Transform:
   - {fileID: 1166246389}
   - {fileID: 208179301}
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1696284537
 GameObject:

--- a/Assets/Scripts/Enemy/AttackStrategy.meta
+++ b/Assets/Scripts/Enemy/AttackStrategy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fa6337a341f2fbe439452fe2d5932f3d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/AttackStrategy/AttackStrategy.cs
+++ b/Assets/Scripts/Enemy/AttackStrategy/AttackStrategy.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public interface IAttackStrategy
+{
+    void ExecuteAttack(Enemy enemy);
+}
+
+
+public class AttackStrategy : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/Scripts/Enemy/AttackStrategy/AttackStrategy.cs.meta
+++ b/Assets/Scripts/Enemy/AttackStrategy/AttackStrategy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f2f9831147e6454d9cc4086db67e3b4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/AttackStrategy/DebuffAttackStrategy.cs
+++ b/Assets/Scripts/Enemy/AttackStrategy/DebuffAttackStrategy.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DebuffAttackStrategy : IAttackStrategy
+{
+    public void ExecuteAttack(Enemy enemy)
+    {
+        if (enemy is MeleeEnemy meleeEnemy)
+        {
+            meleeEnemy.PerformAttack();
+        }
+    }
+}

--- a/Assets/Scripts/Enemy/AttackStrategy/DebuffAttackStrategy.cs.meta
+++ b/Assets/Scripts/Enemy/AttackStrategy/DebuffAttackStrategy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27dddc7f4d19ab549919cab4cd3ea036
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/AttackStrategy/MeleeAttackStrategy.cs
+++ b/Assets/Scripts/Enemy/AttackStrategy/MeleeAttackStrategy.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MeleeAttackStrategy : IAttackStrategy
+{
+    public void ExecuteAttack(Enemy enemy)
+    {
+        if (enemy is MeleeEnemy meleeEnemy)
+        {
+            meleeEnemy.PerformAttack();
+        }
+    }
+}

--- a/Assets/Scripts/Enemy/AttackStrategy/MeleeAttackStrategy.cs.meta
+++ b/Assets/Scripts/Enemy/AttackStrategy/MeleeAttackStrategy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3154e64a262b3f54e808160ede58dfad
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/AttackStrategy/RangedAttackStrategy.cs
+++ b/Assets/Scripts/Enemy/AttackStrategy/RangedAttackStrategy.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RangedAttackStrategy : IAttackStrategy
+{
+    public void ExecuteAttack(Enemy enemy)
+    {
+        if (enemy is RangedEnemy rangedEnemy)
+        {
+            rangedEnemy.ShootProjectile();
+        }
+    }
+}

--- a/Assets/Scripts/Enemy/AttackStrategy/RangedAttackStrategy.cs.meta
+++ b/Assets/Scripts/Enemy/AttackStrategy/RangedAttackStrategy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bf50453422747d2448f3e0527a9a428e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/DebuffHitBox.cs
+++ b/Assets/Scripts/Enemy/DebuffHitBox.cs
@@ -1,0 +1,21 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DebuffHitBox : HitBox
+{
+    [SerializeField] private float slowAmount = 0.3f;
+    [SerializeField] private float slowDuration = 3f;
+
+    protected override void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.tag == "Player" && !isHit)
+        {
+            isHit = true;
+            collision.GetComponent<Status>().TakeDamage(enemy, damage, 0, false);
+            collision.GetComponent<PlayerStatus>().ApplySlow(slowAmount, slowDuration);
+        }
+
+        gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/Enemy/DebuffHitBox.cs.meta
+++ b/Assets/Scripts/Enemy/DebuffHitBox.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 022178568cd22c3408834ac9f36b0e52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/DebuffMeleeEnemy.cs
+++ b/Assets/Scripts/Enemy/DebuffMeleeEnemy.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DebuffMeleeEnemy : MeleeEnemy
+{
+    public float debuffDuration = 3f;
+    public float debuffAmount = 0.5f;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        SetAttackStrategy(new DebuffAttackStrategy());
+    }
+
+    // HitBox 충돌 이벤트에서 호출될 수 있음
+    public void ApplyDebuff(GameObject target)
+    {
+        PlayerStatus status = target.GetComponent<PlayerStatus>();
+        if (status != null)
+        {
+            //status.TakeDamage(this.gameObject, enemyStatus.EnemyStatusData.Atk, 0, false);
+            //status.ApplyDebuff(debuffAmount, debuffDuration);
+        }
+    }
+}

--- a/Assets/Scripts/Enemy/DebuffMeleeEnemy.cs.meta
+++ b/Assets/Scripts/Enemy/DebuffMeleeEnemy.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2d28eedbf8a2c3e408e4804710d8718c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/DebuffToPlayer.meta
+++ b/Assets/Scripts/Enemy/DebuffToPlayer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 10c85d0491d7b1d47917253337d18666
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/DebuffToPlayer/SlowDebuff.cs
+++ b/Assets/Scripts/Enemy/DebuffToPlayer/SlowDebuff.cs
@@ -1,0 +1,15 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SlowDebuff
+{
+    public float amount; // 0.3 = 30% 감속
+    public float endTime; // 만료 시각
+
+    public SlowDebuff(float amount, float duration)
+    {
+        this.amount = amount;
+        this.endTime = Time.time + duration;
+    }
+}

--- a/Assets/Scripts/Enemy/DebuffToPlayer/SlowDebuff.cs.meta
+++ b/Assets/Scripts/Enemy/DebuffToPlayer/SlowDebuff.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 53bd2087881b68d4f820853a0ff5d3f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/Enemy.cs
+++ b/Assets/Scripts/Enemy/Enemy.cs
@@ -53,6 +53,8 @@ public class Enemy : MonoBehaviour
 
     public bool IsEdgeDetected { get; private set; }
 
+    protected IAttackStrategy attackStrategy;
+
     protected virtual void Awake()
     {
         enemyRigidbody = GetComponent<Rigidbody2D>();
@@ -102,9 +104,9 @@ public class Enemy : MonoBehaviour
         }
     }
 
-    protected virtual void Attack()
+    public virtual void Attack()
     {
-
+        attackStrategy?.ExecuteAttack(this);
     }
 
     protected void CheckPlatformEdge()
@@ -135,5 +137,10 @@ public class Enemy : MonoBehaviour
     {
         yield return new WaitForSeconds(1.5f);
         gameObject.SetActive(false);
+    }
+
+    public virtual void SetAttackStrategy(IAttackStrategy strategy)
+    {
+        attackStrategy = strategy;
     }
 }

--- a/Assets/Scripts/Enemy/HitBox.cs
+++ b/Assets/Scripts/Enemy/HitBox.cs
@@ -6,13 +6,13 @@ using UnityEngine;
 public class HitBox : MonoBehaviour
 {
     [SerializeField]
-    private BoxCollider2D hitBoxCol;
+    protected BoxCollider2D hitBoxCol;
     [SerializeField]
-    private float damage;
+    protected float damage;
 
-    private GameObject enemy;
+    protected GameObject enemy;
 
-    bool isHit;
+    protected bool isHit;
 
     private void Awake()
     {
@@ -36,15 +36,12 @@ public class HitBox : MonoBehaviour
         isHit = false;
     }
 
-    private void OnTriggerEnter2D(Collider2D collision)
+    protected virtual void OnTriggerEnter2D(Collider2D collision)
     {
-        if (collision.tag == "Player")
+        if (collision.tag == "Player" && !isHit)
         {
-            if (!isHit)
-            {
-                isHit = true;
-                collision.gameObject.GetComponent<Status>().TakeDamage(enemy, damage, 0, false);
-            }
+            isHit = true;
+            collision.gameObject.GetComponent<Status>().TakeDamage(enemy, damage, 0, false);
         }
         gameObject.SetActive(false);
     }

--- a/Assets/Scripts/Enemy/MeleeEnemy.cs
+++ b/Assets/Scripts/Enemy/MeleeEnemy.cs
@@ -5,11 +5,12 @@ using UnityEngine;
 public class MeleeEnemy : Enemy
 {
     [SerializeField]
-    private GameObject hitBoxObj;
+    protected GameObject hitBoxObj;
 
     protected override void Awake()
     {
         base.Awake();
+        SetAttackStrategy(new MeleeAttackStrategy());
         AttackRangeCol.size = new Vector2(enemyStatus.EnemyStatusData.AttackRange, AttackRangeCol.size.y);
     }
 
@@ -29,12 +30,9 @@ public class MeleeEnemy : Enemy
 
     }
 
-    protected override void Attack()
+    public void PerformAttack()
     {
-        //base.Attack();
-
-        Debug.Log(transform.right.x);
-        hitBoxObj.transform.localPosition = new Vector2( (transform.rotation.y != 180f ? -1f : 1f), 0.3f);
+        hitBoxObj.transform.localPosition = new Vector2((transform.rotation.y != 180f ? -1f : 1f), 0.3f);
         hitBoxObj.SetActive(true);
     }
 }

--- a/Assets/Scripts/Enemy/RangedEnemy.cs
+++ b/Assets/Scripts/Enemy/RangedEnemy.cs
@@ -10,6 +10,7 @@ public class RangedEnemy : Enemy
     protected override void Awake()
     {
         base.Awake();
+        SetAttackStrategy(new RangedAttackStrategy());
     }
 
     void Start()

--- a/Assets/Scripts/Enemy/StateMachine/AttackState.cs
+++ b/Assets/Scripts/Enemy/StateMachine/AttackState.cs
@@ -5,14 +5,16 @@ using UnityEngine;
 public class AttackState : IState
 {
     private Enemy enemy;
+    private IAttackStrategy attackStrategy;
     private float attackTime;
     private bool isAttacking;
 
-    public AttackState(Enemy enemy)
+    public AttackState(Enemy enemy, IAttackStrategy attackStrategy)
     {
         this.enemy = enemy;
         attackTime = 0.7f;
         isAttacking = false;
+        this.attackStrategy = attackStrategy;
     }
 
     public void Enter()
@@ -21,6 +23,7 @@ public class AttackState : IState
         {
             isAttacking = true;
             enemy.EnemyAnimator.SetTrigger("Attack");
+            attackStrategy.ExecuteAttack(enemy);
             enemy.StateMachine.StartCoroutine(enemy.StateMachine.AttackCoroutine(attackTime));
         }
         else

--- a/Assets/Scripts/Enemy/StateMachine/EnemyAIController.cs
+++ b/Assets/Scripts/Enemy/StateMachine/EnemyAIController.cs
@@ -22,13 +22,18 @@ public class EnemyAIController : MonoBehaviour
         this.chaseState = new ChaseState(enemy);
         this.deadState = new DeadState(enemy);
 
-        if (enemy is RangedEnemy rangedEnemy)
+        // 공격 전략 주입
+        if (enemy is DebuffMeleeEnemy)
         {
-            this.attackState = new RangedAttackState(rangedEnemy);
+            attackState = new AttackState(enemy, new DebuffAttackStrategy());
+        }
+        else if (enemy is RangedEnemy)
+        {
+            attackState = new AttackState(enemy, new RangedAttackStrategy());
         }
         else
         {
-            this.attackState = new MeleeAttackState(enemy);
+            attackState = new AttackState(enemy, new MeleeAttackStrategy());
         }
 
         isChasing = false;

--- a/Assets/Scripts/PlayerStatus.cs
+++ b/Assets/Scripts/PlayerStatus.cs
@@ -17,6 +17,9 @@ public class PlayerStatus : Status
     private float totalDamageReduction;
     private float ignoreDamageReduction;
 
+    private List<SlowDebuff> slowDebuffs = new();
+    private float baseMoveSpeed;
+
     public float Level { get { return level; } set { level = value; } }
     public float CriticalPercent { get { return criticalPercent; } set { criticalPercent = value; } }
     public float CriticalDamage { get { return criticalDamage; } set { criticalDamage = (value < 0.0f) ? 0 : value; } }
@@ -131,13 +134,29 @@ public class PlayerStatus : Status
         criticalPercent = 0;
         priceAdditional = 0;
         ignoreDamageReduction = 0;
+
+        baseMoveSpeed = MoveSpeed;
     }
 
     void Start()
     {
 
     }
-    
+
+    private void Update()
+    {
+        if (slowDebuffs.Count == 0) return;
+
+        // 뒤에서 앞으로 탐색하며 만료된 디버프 제거
+        for (int i = slowDebuffs.Count - 1; i >= 0; i--)
+        {
+            if (Time.time >= slowDebuffs[i].endTime)
+                slowDebuffs.RemoveAt(i);
+        }
+
+        RecalculateSlow();
+    }
+
     protected override void Dead()
     {
         //gameObject.GetComponent<PlayerController>().Dead();
@@ -156,4 +175,23 @@ public class PlayerStatus : Status
 
 
     }
+
+    public void ApplySlow(float amount, float duration)
+    {
+        // 새 디버프 추가
+        slowDebuffs.Add(new SlowDebuff(amount, duration));
+        // 즉시 재계산
+        RecalculateSlow();
+    }
+
+    private void RecalculateSlow()
+    {
+        float totalSlow = 0f;
+        foreach (var debuff in slowDebuffs)
+            totalSlow += debuff.amount;
+
+        totalSlow = Mathf.Clamp01(totalSlow); // 최대 100%(=이동 불가) 제한
+        MoveSpeed = baseMoveSpeed * (1f - totalSlow);
+    }
+
 }

--- a/Assets/Scripts/Status.cs
+++ b/Assets/Scripts/Status.cs
@@ -60,22 +60,36 @@ public class Status : MonoBehaviour
         }
     }
     public float TotalAttackSpeed { get { return totalAttackSpeed; } }
-    
-    public float MoveSpeed { get { return moveSpeed; } set { moveSpeed = value; } }
+
+    public float MoveSpeed
+    {
+        get { return moveSpeed; }
+        set
+        {
+            moveSpeed = value;
+            UpdateTotalMoveSpeed();
+        }
+    }
+
+    private void UpdateTotalMoveSpeed()
+    {
+        if (additionalMoveSpeed < -1f)
+        {
+            totalMoveSpeed = moveSpeed + (moveSpeed * -1);
+        }
+        else
+        {
+            totalMoveSpeed = moveSpeed + (moveSpeed * additionalMoveSpeed);
+        }
+    }
+
     public float AdditionalMoveSpeed
     {
         get { return additionalMoveSpeed; }
         set
         {
             additionalMoveSpeed = value;
-            if (additionalMoveSpeed < -1f)
-            {
-                totalMoveSpeed = MoveSpeed + (MoveSpeed * -1);
-            }
-            else
-            {
-                totalMoveSpeed = MoveSpeed + (MoveSpeed * additionalMoveSpeed);
-            }
+            UpdateTotalMoveSpeed();
         }
     }
     public float TotalMoveSpeed { get { return totalMoveSpeed; } }


### PR DESCRIPTION
- 이슈 번호 : #132 
Closes #132   
- 구현 사항
  - 기존 MeleeEnemy를 상속받아 플레이어에 비교적 적은 데미지와 둔화 디버프 효과를 부여하는 적 구현
  - 공격 전략 분리 적용:
    - IAttackStrategy 인터페이스 도입
    - Melee, Ranged, Debuff 공격 전략을 별도 클래스로 정의
    - Enemy 클래스에서 Attack() 호출 시 현재 전략에 따라 실행. 향후 확장 시 Attack 호출 제거 후 전략 실행 호출로 수정.
  - 근접 공격 적 HitBox를 상속하여 DebuffHitBox 구현
  - PlayerStatus 수정:
    - 둔화 디버프 적용 로직 추가
    - MoveSpeed 또는 AdditionalMoveSpeed 변경 시 TotalMoveSpeed가 자동 갱신되도록 수정